### PR TITLE
Fix button rendering

### DIFF
--- a/src/button.js
+++ b/src/button.js
@@ -29,15 +29,19 @@ class Button extends BrightwheelComponent {
     );
 
     // Only render an icon if specified
+    let icon;
+
+    let iconClasses = classNames(
+      {'icon-text' : this.properties.text !== undefined}
+    )
+
     if (this.properties.icon !== undefined) {
-      this.children.push(<Icon icon={this.properties.icon} classNames='icon-text' />);
+      icon = <Icon icon={this.properties.icon} classNames={iconClasses} />
     }
 
     return (
       <button {...this.properties.attributes} className={classes}>
-        {this.children.map(function(child) {
-          return child;
-        })}
+        {icon}
         {this.properties.text}
       </button>
     );

--- a/src/button.js
+++ b/src/button.js
@@ -20,8 +20,9 @@ class Button extends BrightwheelComponent {
   render() {
 
     let classes = classNames(
-      'btn', {
-        [`btn-${this.properties.type}`]: this.properties.type !== undefined,
+      'btn',
+      this.properties.type !== undefined ? [`btn-${this.properties.type}`] : 'btn-default',
+      {
         [`btn-${this.properties.size}`]: this.properties.size !== undefined
       },
       this.properties.classNames

--- a/src/button.js
+++ b/src/button.js
@@ -35,7 +35,9 @@ class Button extends BrightwheelComponent {
 
     return (
       <button {...this.properties.attributes} className={classes}>
-        {this.children}
+        {this.children.map(function(child) {
+          return child;
+        })}
         {this.properties.text}
       </button>
     );

--- a/src/icon.js
+++ b/src/icon.js
@@ -39,6 +39,12 @@ class Icon extends BrightwheelComponent {
     return (<span {...this.properties.attributes} className={classes}></span>);
   }
 
+  update(properties, children) {
+    this.properties = properties;
+    this.children = children;
+    return etch.update(this);
+  }
+
 }
 
 export default Icon;

--- a/test/button-spec.js
+++ b/test/button-spec.js
@@ -19,6 +19,11 @@ describe('Button', () => {
       expect(myButton.virtualElement.tagName).to.equal('BUTTON');
     });
 
+    it('should render the correct default classes', () => {
+      let myButton = new Button({ text: 'My Button'}, []);
+      expect(myButton.virtualElement.properties.className).to.equal('btn btn-default');
+     });
+
     it('should render the correct text', () => {
       let myButton = new Button({ text: 'My Button', type: 'primary', size: 'mini'}, []);
       expect(myButton.virtualElement.children[0]).to.contain.keys({ text: 'My Button'});


### PR DESCRIPTION
Fixes #1 

This PR makes a few changes to the way buttons are rendered.
- It ensures buttons receive a default class of `btn-default` if no value is specified for `properties.type`
- It conditionally renders `icon-text` as part of a Button icon's classes when the button has text
- It renders an icon as conditional JSX rather than pushing it into the Button's children

**Implementing an `update()` method for Icons**

aa1788f implements an `update()` method for that replaces an icon's properties and children with new values passed in.  

Before, this class inherited the barebones method from the `BrightwheelComponent` superclass that ignores any values passed and only calls `etch.update(this)`.  This caused issues with icons nested within buttons (as ComponentWidgets) where the button updates would not propagate to the nested icon.  Overriding the inherited `update()` method for icons with something that passes new values seems to have resolved the issue.

This method will likely need some finessing in the future, but for now it's good to have it working.  It would also be worth testing other components that exist as nested ComponentWidgets to see if they need to be updated as well.