### PR TITLE
Default component update

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install --save brightwheel
 
 Include Photon styles in your HTML file's `<head>`.
 ```html
-<script src="path/to/photon.css" charset="utf-8"></script>
+<link rel="stylesheet" href="path/to/photon.css" media="screen" title="no title">
 ```
 
 Import Brightwheel components into your project.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brightwheel",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Build beautiful Electron user interfaces with Photon and Etch",
   "repository": "loranallensmith/brightwheel",
   "author": "Allen Smith &lt;loranallensmith@github.com&gt;",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brightwheel",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Build beautiful Electron user interfaces with Photon and Etch",
   "repository": "loranallensmith/brightwheel",
   "author": "Allen Smith &lt;loranallensmith@github.com&gt;",

--- a/src/brightwheel-component.js
+++ b/src/brightwheel-component.js
@@ -41,6 +41,8 @@ class BrightwheelComponent {
   update (properties, children) {
 
    // perform custom update logic here...
+   this.properties = properties;
+   this.children = children;
 
    // then call `etch.update`, which is async and returns a promise
    return etch.update(this)

--- a/src/icon.js
+++ b/src/icon.js
@@ -39,11 +39,6 @@ class Icon extends BrightwheelComponent {
     return (<span {...this.properties.attributes} className={classes}></span>);
   }
 
-  update(properties, children) {
-    this.properties = properties;
-    this.children = children;
-    return etch.update(this);
-  }
 
 }
 


### PR DESCRIPTION
This Pull Request implements a default behavior for a component's `update()` method that replaces the current properties and children with those passed as arguments.

In the current code, this method does nothing with the values passed in, making it especially difficult to update components that haven't overridden `BrightwheelComponent`'s update method.  

It might be nice to eventually implement custom behavior to make updating components easier, but adding this default behavior is a good start that will provide functionality without being overly prescriptive.