### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,13 @@
   "repository": "loranallensmith/brightwheel",
   "author": "Allen Smith &lt;loranallensmith@github.com&gt;",
   "license": "MIT",
-  "keywords": ["electron", "etch", "user interface", "UI", "react"],
+  "keywords": [
+    "electron",
+    "etch",
+    "user interface",
+    "UI",
+    "react"
+  ],
   "main": "index.js",
   "jsnext:main": "index.es6.js",
   "babel": {
@@ -25,12 +31,12 @@
   "dependencies": {
     "babel-runtime": "^6.6.1",
     "classnames": "^2.2.5",
-    "etch": "^0.7.1"
+    "etch": "^0.8.0"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",
     "babel-core": "^6.8.0",
-    "babel-eslint": "^6.0.4",
+    "babel-eslint": "^7.1.0",
     "babel-plugin-transform-runtime": "^6.8.0",
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.6.0",
@@ -42,14 +48,14 @@
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
     "del": "^2.2.0",
-    "eslint": "^2.9.0",
-    "eslint-config-airbnb": "^8.0.0",
-    "eslint-plugin-import": "^1.6.1",
-    "eslint-plugin-jsx-a11y": "^1.0.4",
-    "eslint-plugin-react": "^5.0.1",
+    "eslint": "^3.9.1",
+    "eslint-config-airbnb": "^12.0.0",
+    "eslint-plugin-import": "^1.16.0",
+    "eslint-plugin-jsx-a11y": "^2.2.3",
+    "eslint-plugin-react": "^6.5.0",
     "istanbul": "^1.0.0-alpha.2",
-    "mocha": "^2.4.5",
-    "rollup": "^0.26.2",
+    "mocha": "^3.1.2",
+    "rollup": "^0.36.3",
     "rollup-plugin-babel": "^2.4.0",
     "sinon": "^2.0.0-pre"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brightwheel",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Build beautiful Electron user interfaces with Photon and Etch",
   "repository": "loranallensmith/brightwheel",
   "author": "Allen Smith &lt;loranallensmith@github.com&gt;",


### PR DESCRIPTION
This update dependencies to the current available versions with the exception of `eslint-config-import`, for which the newest version `2.1.0` currently causes peer dependency issues.