### PR TITLE
Add property setter and unsetter

### DIFF
--- a/src/brightwheel-component.js
+++ b/src/brightwheel-component.js
@@ -54,24 +54,39 @@ class BrightwheelComponent {
    await etch.destroy(this)
 
    // then perform custom teardown logic here...
-
  }
 
   // Property Setter
   // Use this to update component state and re-render the component
   setProperty (properties) {
+    // If the newly passed properties contain an attributes object
+    if (properties.hasOwnProperty('attributes')) {
+      // Check to see if the component has any attributes specified
+      if (this.properties.attributes) {
+        // Combine old attributes and new ones
+        let newAttributes = Object.assign({}, this.properties.attributes, properties.attributes)
+        properties.attributes = newAttributes
+      }
+    }
+    // Combine existing properties and newly passed ones
     let newProperties = Object.assign({}, this.properties, properties)
+
+    // Update component with new properties
     this.update(newProperties)
   }
 
   // Property Unsetter
   // Use this to unset a property and re-render the component
   unsetProperty (property) {
+    // Check for the specified property in component properties
     if (this.properties[property]) {
       delete this.properties[property]
+      // Check for the specified property in the component attributes
+    } else if (this.properties.attributes[property]) {
+      delete this.properties.attributes[property]
     }
     this.update(this.properties)
   }
 }
 
-export default BrightwheelComponent;
+export default BrightwheelComponent

--- a/src/brightwheel-component.js
+++ b/src/brightwheel-component.js
@@ -38,11 +38,9 @@ class BrightwheelComponent {
 
 
   // Optional: Update the component with new properties and children
-  update (properties, children) {
-
+  update (properties) {
    // perform custom update logic here...
    this.properties = properties;
-   this.children = children;
 
    // then call `etch.update`, which is async and returns a promise
    return etch.update(this)
@@ -59,6 +57,21 @@ class BrightwheelComponent {
 
  }
 
+  // Property Setter
+  // Use this to update component state and re-render the component
+  setProperty (properties) {
+    let newProperties = Object.assign({}, this.properties, properties)
+    this.update(newProperties)
+  }
+
+  // Property Unsetter
+  // Use this to unset a property and re-render the component
+  unsetProperty (property) {
+    if (this.properties[property]) {
+      delete this.properties[property]
+    }
+    this.update(this.properties)
+  }
 }
 
 export default BrightwheelComponent;

--- a/test/shared-behavior-spec.js
+++ b/test/shared-behavior-spec.js
@@ -24,6 +24,12 @@ describe('Shared Behavior', () => {
       myButton.setProperty({text: 'Updated'})
       expect(myButton.properties.text).to.equal('Updated')
     })
+
+    it('should work with attributes too', () => {
+      let myButton = new Button({text: 'My Button', attributes: {type: 'submit'}}, [])
+      myButton.setProperty({attributes: {id: 1}})
+      expect(myButton.properties.attributes.type).to.equal('submit')
+    })
   })
   describe('unsetProperty', () => {
     it('should unset an existing property', () => {
@@ -31,6 +37,13 @@ describe('Shared Behavior', () => {
       myButton.unsetProperty('text')
       expect(myButton.properties.text).to.not.exist
       expect(myButton.properties.icon).to.equal('check')
+    })
+
+    it('should work for attributes too', () => {
+      let myButton = new Button({text: 'My Button', attributes: {id: 1, type: 'submit'}}, [])
+      myButton.unsetProperty('id')
+      expect(myButton.properties.attributes.type).to.equal('submit')
+      expect(myButton.properties.attributes.id).to.not.exist
     })
   })
 })

--- a/test/shared-behavior.js
+++ b/test/shared-behavior.js
@@ -1,0 +1,36 @@
+/**
+ * brightwheel
+ *
+ * Copyright © 2016 Allen Smith &lt;loranallensmith@github.com&gt;. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+
+import { expect } from 'chai'
+import Button from '../src/button'
+
+describe('Shared Behavior', () => {
+  describe('setProperty', () => {
+    it('should add a new property', () => {
+      let myButton = new Button({text: 'My Button'}, [])
+      myButton.setProperty({icon: 'check'})
+      expect(myButton.properties.text).to.equal('My Button')
+      expect(myButton.properties.icon).to.equal('check')
+    })
+
+    it('should edit an existing property', () => {
+      let myButton = new Button({text: 'My Button'}, [])
+      myButton.setProperty({text: 'Updated'})
+      expect(myButton.properties.text).to.equal('Updated')
+    })
+  })
+  describe('unsetProperty', () => {
+    it('should unset an existing property', () => {
+      let myButton = new Button({text: 'My button', icon: 'check'}, [])
+      myButton.unsetProperty('text')
+      expect(myButton.properties.text).to.not.exist
+      expect(myButton.properties.icon).to.equal('check')
+    })
+  })
+})


### PR DESCRIPTION
This PR adds setter and un-setter methods to all components for easier state/property management.

The setProperty method was cribbed from an example at https://arcath.net/2017/05/etch-router/ and is similar to React's setState function.  It takes an object with keys and values, merges that object with the existing component's properties and then passes the combined result to the component's `update()` method.

This PR also modifies the update() method for all components to only take `properties` as an argument.  The intent here is to manage children directly via `component.children` (or possibly via helper methods) instead of passing a bunch of unnecessary data to `update()`.  It might even make sense to refactor this further to pull `properties` out of `update()` and simply use that method to explicitly refresh components after changing their state/properties.
