### PR TITLE
WIP: Conditional application styling

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -24,7 +24,7 @@ class Application extends BrightwheelComponent {
     this.properties.stylesheetPaths = {
       // TODO: Implement null stylesheets for other platforms
       // aix: null,
-      darwin: 'node_modules/photonkit/dist/css/photon.css',
+      darwin: 'node_modules/photonkit/dist/css/photon.css'
       // freebsd: null,
       // linux: null,
       // openbsd: null,
@@ -35,6 +35,9 @@ class Application extends BrightwheelComponent {
     // Set the active stylesheet based on the current process.platform value.
     this.setActiveStyleSheet(process.platform)
 
+    // Initialize this component with etch.
+    etch.initialize(this)
+
   }
 
   setActiveStyleSheet(name, path = undefined) {
@@ -43,7 +46,7 @@ class Application extends BrightwheelComponent {
       this.properties.activeStylesheetPath = this.properties.stylesheetPaths[name]
     }
     // Allow for custom stylesheets
-    else if (name === 'custom' && typeof path !== "undefined") {
+    else if (name === 'custom' && typeof path !== 'undefined') {
       this.properties.activeStylesheetPath = path
     }
     else {

--- a/src/application.js
+++ b/src/application.js
@@ -16,6 +16,41 @@ import BrightwheelComponent from './brightwheel-component';
 
 class Application extends BrightwheelComponent {
 
+  constructor(properties, children) {
+
+    // Construct a basic BrightwheelComponent from the parameters given
+    super(properties, children)
+
+    this.properties.stylesheetPaths = {
+      // TODO: Implement null stylesheets for other platforms
+      // aix: null,
+      darwin: 'node_modules/photonkit/dist/css/photon.css',
+      // freebsd: null,
+      // linux: null,
+      // openbsd: null,
+      // sunos: null,
+      // win32: null
+    }
+
+    // Set the active stylesheet based on the current process.platform value.
+    this.setActiveStyleSheet(process.platform)
+
+  }
+
+  setActiveStyleSheet(name, path = undefined) {
+    // If this style name has a built-in stylesheet associated it
+    if (this.properties.stylesheetPaths.hasOwnProperty(name)) {
+      this.properties.activeStylesheetPath = this.properties.stylesheetPaths[name]
+    }
+    // Allow for custom stylesheets
+    else if (name === 'custom' && typeof path !== "undefined") {
+      this.properties.activeStylesheetPath = path
+    }
+    else {
+      throw Error('The the specified style is not supported.')
+    }
+  }
+
   render() {
 
     return (
@@ -24,7 +59,7 @@ class Application extends BrightwheelComponent {
           <meta charset="utf-8" />
           <title></title>
 
-          <link rel="stylesheet" href="node_modules/photonkit/dist/css/photon.css" media="screen" title="no title" charset="utf-8" />
+          <link rel="stylesheet" href={this.properties.activeStylesheetPath} media="screen" title="no title" charset="utf-8" />
 
         </head>
         <body>{this.children}</body>


### PR DESCRIPTION
This PR expands on the functionality of the `Application` object to help support dynamic stylesheet selection based on the current `process.platform` (or a passed custom platform).

The full list of platforms still needs to be implemented.  Right now, the only one that is active is the one that loads photon for `darwin` platforms.

Before merging these changes, we need to add specs that test this new conditional behavior.